### PR TITLE
Instructor 1.7.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,15 +48,10 @@ test:
   requires:
     - python
     - pip
-    - pytest
-    - python-dotenv
   imports:
     - instructor
-  source_files:
-    - tests
   commands:
     - pip check
-    - pytest tests -v
 
 about:
   home: https://github.com/jxnl/instructor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<310]
   number: 0
-# Though it is avaible upstream for 3.9, we’ll limit the package to Python 3.10 and above,
+# Though it is available upstream for 3.9, we’ll limit the package to Python 3.10 and above,
 # since the newer typing syntax breaks all 3.9 builds.
 
+# We'll keep setuptools unpinned—upstream caps <72.10; needed for Django 5.2 on Py 3.13
 requirements:
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 # Though it is available upstream for 3.9, we’ll limit the package to Python 3.10 and above,
 # since the newer typing syntax breaks all 3.9 builds.
 
-# We'll keep setuptools unpinned—upstream caps <72.10; needed for Django 5.2 on Py 3.13
 requirements:
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,21 +36,21 @@ requirements:
     - jiter <0.9,>=0.6.1
     - jinja2 <4.0.0,>=3.1.4
   run_constrained:
-  - anthropic ==0.48.0
-  - xmltodict >=0.13,<0.15
-  - groq >=0.4.2,<0.14.0
-  - cohere >=5.1.8,<6.0.0
-  - google-generativeai >=0.8.2,<1.0.0
-  - jsonref >=1.1.0,<2.0.0
-  - google-cloud-aiplatform >=1.53.0,<2.0.0
-  - cerebras-cloud-sdk >=1.5.0,<2.0.0
-  - fireworks-ai >=0.15.4,<1.0.0
-  - writer-sdk >=1.2.0,<2.0.0
-  - boto3 >=1.34.0,<2.0.0
-  - mistralai >=1.5.1,<2.0.0
-  - openai >=1.52.0,<2.0.0
-  - google-genai >=1.5.0
-  - litellm >=1.35.31,<2.0.0
+    - anthropic ==0.48.0
+    - xmltodict >=0.13,<0.15
+    - groq >=0.4.2,<0.14.0
+    - cohere >=5.1.8,<6.0.0
+    - google-generativeai >=0.8.2,<1.0.0
+    - jsonref >=1.1.0,<2.0.0
+    - google-cloud-aiplatform >=1.53.0,<2.0.0
+    - cerebras-cloud-sdk >=1.5.0,<2.0.0
+    - fireworks-ai >=0.15.4,<1.0.0
+    - writer-sdk >=1.2.0,<2.0.0
+    - boto3 >=1.34.0,<2.0.0
+    - mistralai >=1.5.1,<2.0.0
+    - openai >=1.52.0,<2.0.0
+    - google-genai >=1.5.0
+    - litellm >=1.35.31,<2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,7 @@ build:
   skip: true  # [py<310]
   number: 0
 # Though it is available upstream for 3.9, we’ll limit the package to Python 3.10 and above,
-# since the newer typing syntax breaks all 3.9 builds.
-
+# since the newer typing syntax breaks all 3.9 builds.  
 requirements:
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,10 @@ build:
   entry_points:
     - instructor = instructor.cli.cli:app
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   number: 0
+# Though it is avaible upstream for 3.9, we’ll limit the package to Python 3.10 and above,
+# since the newer typing syntax breaks all 3.9 builds.
 
 requirements:
   host:
@@ -63,6 +65,14 @@ about:
   summary: structured outputs for llm
   license: MIT
   license_file: LICENSE
+  description : |
+    Instructor is a Python library that provides a simple and efficient way to
+    create structured outputs for large language models (LLMs). It allows you to
+    define the structure of the output you want from the LLM, making it easier to
+    work with the generated text. The library is designed to be easy to use and
+    integrate into your existing projects.
+  dev_url: https://github.com/jxnl/instructor
+  doc_url: https://github.com/jxnl/instructor
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,6 +65,7 @@ about:
   summary: structured outputs for llm
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   description : |
     Instructor is a Python library that provides a simple and efficient way to
     create structured outputs for large language models (LLMs). It allows you to

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,6 @@ requirements:
 
 test:
   requires:
-    - python
     - pip
   imports:
     - instructor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "instructor" %}
 {% set version = "1.7.9" %}
-{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -13,18 +12,18 @@ source:
 build:
   entry_points:
     - instructor = instructor.cli.cli:app
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - poetry-core
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
+    - python
     - openai >=1.52.0,<2.0.0
     - pydantic >=2.8.0,<3.0.0
     - docstring_parser >=0.16.0,<0.17.0
@@ -56,7 +55,7 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }}
+    - python
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,13 +36,21 @@ requirements:
     - jiter <0.9,>=0.6.1
     - jinja2 <4.0.0,>=3.1.4
   run_constrained:
-    - fastapi<0.116.0,>=0.109.2
-    - graphviz<1.0.0,>=0.20.3
-    - pandas<3.0.0,>=2.2.0
-    - redis<6.0.0,>=5.0.1
-    - tabulate<1.0.0,>=0.9.0
-    - xmltodict<0.15,>=0.13
-    - datasets<4.0.0,>=3.0.1
+  - anthropic ==0.48.0
+  - xmltodict >=0.13,<0.15
+  - groq >=0.4.2,<0.14.0
+  - cohere >=5.1.8,<6.0.0
+  - google-generativeai >=0.8.2,<1.0.0
+  - jsonref >=1.1.0,<2.0.0
+  - google-cloud-aiplatform >=1.53.0,<2.0.0
+  - cerebras-cloud-sdk >=1.5.0,<2.0.0
+  - fireworks-ai >=0.15.4,<1.0.0
+  - writer-sdk >=1.2.0,<2.0.0
+  - boto3 >=1.34.0,<2.0.0
+  - mistralai >=1.5.1,<2.0.0
+  - openai >=1.52.0,<2.0.0
+  - google-genai >=1.5.0
+  - litellm >=1.35.31,<2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,9 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/jxnl/instructor/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/instructor-ai/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: 1a7a8f80103f0ed3dc7bb60689772e2e21f5e185586107f39022c983fa97204d
-
 build:
   entry_points:
     - instructor = instructor.cli.cli:app
@@ -16,7 +15,7 @@ build:
   skip: true  # [py<310]
   number: 0
 # Though it is available upstream for 3.9, we’ll limit the package to Python 3.10 and above,
-# since the newer typing syntax breaks all 3.9 builds.  
+# since the newer typing syntax breaks all 3.9 builds.
 requirements:
   host:
     - python
@@ -27,37 +26,37 @@ requirements:
     - python
     - openai >=1.52.0,<2.0.0
     - pydantic >=2.8.0,<3.0.0
-    - docstring_parser >=0.16.0,<0.17.0
-    - typer >=0.9.0,<1.0.0
-    - rich >=13.7.0,<14.0.0
-    - aiohttp >=3.9.1,<4.0.0
-    - requests >=2.32.3
+    - docstring_parser <1.0,>=0.16
+    - typer <1.0.0,>=0.9.0
+    - rich <14.0.0,>=13.7.0
+    - aiohttp <4.0.0,>=3.9.1
+    - requests <3.0.0,>=2.32.3
     - tenacity >=9.0.0,<10.0.0
     - pydantic-core >=2.18.0,<3.0.0
-    - jiter >=0.6.1,<0.7
-    - jinja2 >=3.1.4
+    - jiter <0.9,>=0.6.1
+    - jinja2 <4.0.0,>=3.1.4
   run_constrained:
-    - fastapi >=0.109.2,<0.110.0
-    - redis-py >=5.0.1,<6.0.0
-    - diskcache >=5.6.3,<6.0.0
-    - pandas >=2.2.0,<3.0.0
-    - tabulate >=0.9.0,<0.10.0
-    - pydantic_extra_types >=2.6.0,<3.0.0
-    - litellm >=1.0.0,<2.0.0
-    - anthropic >=0.23.1,<0.24.0
-    - xmltodict >=0.13.0,<0.14.0
-    - groq >=0.4.2,<0.5.0
-    - cohere >=5.1.8,<6.0.0
-    - mistralai >=0.1.8,<0.2.0
+    - fastapi<0.116.0,>=0.109.2
+    - graphviz<1.0.0,>=0.20.3
+    - pandas<3.0.0,>=2.2.0
+    - redis<6.0.0,>=5.0.1
+    - tabulate<1.0.0,>=0.9.0
+    - xmltodict<0.15,>=0.13
+    - datasets<4.0.0,>=3.0.1
 
 test:
-  imports:
-    - instructor
-  commands:
-    - pip check
   requires:
     - python
     - pip
+    - pytest
+    - python-dotenv
+  imports:
+    - instructor
+  source_files:
+    - tests
+  commands:
+    - pip check
+    - pytest tests -v
 
 about:
   home: https://github.com/jxnl/instructor


### PR DESCRIPTION
> ## ☆ Instructor 1.7.9 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7939) 
[Upstream](https://github.com/instructor-ai/instructor)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.10. Though it is available [upstream](https://github.com/instructor-ai/instructor) for 3.9, we’ll limit the package to Python 3.10 and above since the newer typing syntax breaks all 3.9 builds.
> *  Updated `about` section